### PR TITLE
add missing openssl dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,10 @@
   <author>Aldebaran</author>
 
   <build_depend>boost</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>boost</run_depend>
+  <run_depend>libssl-dev</run_depend>
 </package>


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

Edit: sorry wrong branch, see https://github.com/ros-naoqi/libqi-release/pull/9