### PR TITLE
[melodic] add missing OpenSSL dependency from package.xml

### DIFF
--- a/melodic/package.xml
+++ b/melodic/package.xml
@@ -14,8 +14,10 @@
   <author>Aldebaran</author>
 
   <build_depend>boost</build_depend>
+  <build_depend>libssl-dev</build_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>boost</run_depend>
+  <run_depend>libssl-dev</run_depend>
 </package>


### PR DESCRIPTION
Follow-up of https://github.com/ros-naoqi/libqi-release/commit/253804f094f2e4efe4de57d004a8f171fc204291#r36451067

Without this it fails to build with:
```
CMake Error at /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
    Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
    system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
    OPENSSL_INCLUDE_DIR)
```